### PR TITLE
Enable userbot mode and webhook forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+TG_API_ID=your_api_id
+TG_API_HASH=your_api_hash
+TG_SESSION_NAME=tg_userbot
+TG_PHONE_NUMBER=+10000000000
+WEBHOOK_URL=https://your.webhook.url
+WEBHOOK_API_KEY=secret-api-key
+TG_FILES_CHAT_ID=0

--- a/README.md
+++ b/README.md
@@ -54,6 +54,15 @@ And start up services:
 docker-compose up
 ```
 
+### Configuration
+
+1.  Copy `.env.example` to `.env` and populate your Telegram API credentials, session name and phone number.
+2.  Specify `WEBHOOK_URL` where incoming messages will be forwarded.
+3.  Run the services with `docker-compose up`. When `receiver` starts for the first time it will prompt for the Telegram code to complete login.
+   Subsequent runs will reuse the saved session file.
+
+Use the **sender** service endpoints to send messages from your server to Telegram.
+
 **Sender** service API can be found on http://0.0.0.0:8001 and docs on http://0.0.0.0:8001/docs
 
 

--- a/receiver/api_driver/driver.py
+++ b/receiver/api_driver/driver.py
@@ -10,8 +10,8 @@ from .logger import gateway_api_driver_logger_init
 
 
 class GatewayAPIDriver:
-    _api_root_url: str = settings.GW_ROOT_URL
-    _api_key: str = settings.GW_API_KEY
+    _webhook_url: str = settings.WEBHOOK_URL
+    _api_key: str = settings.WEBHOOK_API_KEY
 
     logger: logging.Logger = gateway_api_driver_logger_init()
 
@@ -22,27 +22,18 @@ class GatewayAPIDriver:
             'body: {body} error: {error}'
         )
 
-    class Route:
-        USERS: str = '/users'
-
     @classmethod
-    async def _build_url(cls, route: str) -> str:
-        return f'{cls._api_root_url}{route}'
+    async def send_to_webhook(cls, payload: dict) -> httpx.Response:
+        url = cls._webhook_url
+        headers = {
+            'x-api-key': cls._api_key,
+            'Content-Type': 'application/json',
+        }
 
-    @classmethod
-    async def tg_user_create(cls, name: str, chat_id: int) -> httpx.Response:
-        url = await cls._build_url(cls.Route.USERS)
-        headers = {'x-api-key': cls._api_key}
-        data = {'name': name, 'chat_id': chat_id}
-
-        cls._log_request(url, headers, data)
+        cls._log_request(url, headers, payload)
 
         async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=headers,
-                data=data,
-            )
+            resp = await client.post(url, headers=headers, json=payload)
 
         try:
             resp_body = resp.json()

--- a/receiver/config/bot.py
+++ b/receiver/config/bot.py
@@ -6,4 +6,6 @@ bot = TelegramClient(
     session=settings.TG_SESSION_NAME,
     api_id=settings.TG_API_ID,
     api_hash=settings.TG_API_HASH,
-).start(bot_token=settings.TG_BOT_TOKEN)
+)
+
+bot.start(phone=settings.TG_PHONE_NUMBER)

--- a/receiver/config/settings.py
+++ b/receiver/config/settings.py
@@ -6,13 +6,14 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     PROJECT_NAME: str = 'tg-bot-service-receiver'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
     TG_API_ID: str = 'tg-api-id'
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_receiver'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
-    GW_ROOT_URL: str = 'https://some.host'
-    GW_API_KEY: str = 'secret-api-key'
+    WEBHOOK_URL: str = 'https://some.host/webhook'
+    WEBHOOK_API_KEY: str = 'secret-api-key'
+
 
     LOGS_DIR: str = 'logs/'
 
@@ -25,6 +26,7 @@ class Settings(BaseSettings):
         )
 
     class Config:
+        env_file = '.env'
         case_sensitive = True
 
 

--- a/receiver/handlers/__init__.py
+++ b/receiver/handlers/__init__.py
@@ -1,1 +1,2 @@
 from .conversations import familiarize_conv_handler
+from .webhook_forwarder import forward_all_messages

--- a/receiver/handlers/webhook_forwarder.py
+++ b/receiver/handlers/webhook_forwarder.py
@@ -1,0 +1,15 @@
+from telethon import events
+
+from api_driver import GatewayAPIDriver
+from config import bot, settings
+
+
+@bot.on(events.NewMessage)
+async def forward_all_messages(event) -> None:
+    if event.out:
+        return
+
+    payload = event.message.to_dict()
+    payload['phone_number'] = settings.TG_PHONE_NUMBER
+
+    await GatewayAPIDriver.send_to_webhook(payload)

--- a/sender/app/config/bot.py
+++ b/sender/app/config/bot.py
@@ -10,4 +10,4 @@ async def bot_init() -> TelegramClient:
         api_hash=settings.TG_API_HASH,
     )
 
-    return await bot.start(bot_token=settings.TG_BOT_TOKEN)
+    return await bot.start(phone=settings.TG_PHONE_NUMBER)

--- a/sender/app/config/settings.py
+++ b/sender/app/config/settings.py
@@ -10,14 +10,15 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str = 'tg-bot-service-sender'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
     TG_API_ID: str = 'tg-api-id'
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_sender'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
     TG_FILES_CHAT_ID: int = 0
 
     class Config:
+        env_file = '.env'
         case_sensitive = True
 
 


### PR DESCRIPTION
## Summary
- switch both sender and receiver to userbot mode (login by phone)
- forward every incoming message to a configured webhook
- load settings from `.env` and add example configuration
- document configuration and login process

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530cdfc3ac832eb98744cbd87d2439