### PR TITLE
Fix receiver login prompts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Telegram API credentials from https://my.telegram.org for a user application
+TG_API_ID=123456
+TG_API_HASH=your_api_hash
+TG_SESSION_NAME=tg_userbot
+TG_PHONE_NUMBER=+10000000000  # phone number for login
+WEBHOOK_URL=https://your.webhook.url
+WEBHOOK_API_KEY=secret-api-key
+TG_FILES_CHAT_ID=0

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ And start up services:
 docker-compose up
 ```
 
+### Configuration
+
+1.  Copy `.env.example` to `.env`, populate your Telegram API credentials, session name, phone number and webhook information. Keep the file in the repository root next to `docker-compose.yml`.
+2.  Docker Compose loads this file automatically for both services (see `env_file` in `docker-compose.yml`). No extra flags are needed.
+3.  Run the services with `docker-compose up`. When `receiver` starts for the first time it will prompt for the Telegram code (and 2FA password if enabled).
+   Enter the values directly in the compose terminal. Subsequent runs will reuse the saved session file.
+4.  Ensure `TG_API_ID` and `TG_API_HASH` are taken from a **user** application created on [my.telegram.org](https://my.telegram.org) and not from a bot. Otherwise login will fail.
+5.  During image build the latest Telethon is installed automatically. If you build images manually, update Telethon with `pip install -U telethon`.
+
+Use the **sender** service endpoints to send messages from your server to Telegram.
+
 **Sender** service API can be found on http://0.0.0.0:8001 and docs on http://0.0.0.0:8001/docs
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
         build:
             context: ./sender
             dockerfile: Dockerfile
+        env_file:
+          - .env
         ports:
           - 8001:8000
         volumes:
@@ -16,6 +18,8 @@ services:
         build:
             context: ./receiver
             dockerfile: Dockerfile
+        env_file:
+          - .env
         volumes:
           - ./receiver:/receiver
         tty: true

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /receiver
 
 COPY ./pyproject.toml /receiver/
 COPY ./poetry.lock /receiver/
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install
+RUN pip install poetry && poetry config virtualenvs.create false && \
+    poetry install --no-root && \
+    pip install --no-cache-dir -U telethon
 
 COPY ./ /receiver

--- a/receiver/api_driver/driver.py
+++ b/receiver/api_driver/driver.py
@@ -10,8 +10,8 @@ from .logger import gateway_api_driver_logger_init
 
 
 class GatewayAPIDriver:
-    _api_root_url: str = settings.GW_ROOT_URL
-    _api_key: str = settings.GW_API_KEY
+    _webhook_url: str = settings.WEBHOOK_URL
+    _api_key: str = settings.WEBHOOK_API_KEY
 
     logger: logging.Logger = gateway_api_driver_logger_init()
 
@@ -22,27 +22,18 @@ class GatewayAPIDriver:
             'body: {body} error: {error}'
         )
 
-    class Route:
-        USERS: str = '/users'
-
     @classmethod
-    async def _build_url(cls, route: str) -> str:
-        return f'{cls._api_root_url}{route}'
+    async def send_to_webhook(cls, payload: dict) -> httpx.Response:
+        url = cls._webhook_url
+        headers = {
+            'x-api-key': cls._api_key,
+            'Content-Type': 'application/json',
+        }
 
-    @classmethod
-    async def tg_user_create(cls, name: str, chat_id: int) -> httpx.Response:
-        url = await cls._build_url(cls.Route.USERS)
-        headers = {'x-api-key': cls._api_key}
-        data = {'name': name, 'chat_id': chat_id}
-
-        cls._log_request(url, headers, data)
+        cls._log_request(url, headers, payload)
 
         async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=headers,
-                data=data,
-            )
+            resp = await client.post(url, headers=headers, json=payload)
 
         try:
             resp_body = resp.json()

--- a/receiver/config/bot.py
+++ b/receiver/config/bot.py
@@ -6,4 +6,7 @@ bot = TelegramClient(
     session=settings.TG_SESSION_NAME,
     api_id=settings.TG_API_ID,
     api_hash=settings.TG_API_HASH,
-).start(bot_token=settings.TG_BOT_TOKEN)
+)
+
+# `start` is called explicitly in `receiver/main.py` so that the login prompts
+# appear in the container's console when the service launches.

--- a/receiver/config/settings.py
+++ b/receiver/config/settings.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from pydantic import BaseSettings
 
@@ -6,13 +7,14 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     PROJECT_NAME: str = 'tg-bot-service-receiver'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
-    TG_API_ID: str = 'tg-api-id'
+    TG_API_ID: int = 0
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_receiver'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
-    GW_ROOT_URL: str = 'https://some.host'
-    GW_API_KEY: str = 'secret-api-key'
+    WEBHOOK_URL: str = 'https://some.host/webhook'
+    WEBHOOK_API_KEY: str = 'secret-api-key'
+
 
     LOGS_DIR: str = 'logs/'
 
@@ -25,6 +27,7 @@ class Settings(BaseSettings):
         )
 
     class Config:
+        env_file = Path(__file__).resolve().parents[2] / '.env'
         case_sensitive = True
 
 

--- a/receiver/handlers/__init__.py
+++ b/receiver/handlers/__init__.py
@@ -1,1 +1,2 @@
 from .conversations import familiarize_conv_handler
+from .webhook_forwarder import forward_all_messages

--- a/receiver/handlers/webhook_forwarder.py
+++ b/receiver/handlers/webhook_forwarder.py
@@ -1,0 +1,28 @@
+from datetime import date, datetime
+
+from telethon import events
+
+from api_driver import GatewayAPIDriver
+from config import bot, settings
+
+
+@bot.on(events.NewMessage)
+async def forward_all_messages(event) -> None:
+    if event.out:
+        return
+
+    payload = event.message.to_dict()
+    payload['phone_number'] = settings.TG_PHONE_NUMBER
+
+    def _convert(obj):
+        if isinstance(obj, (datetime, date)):
+            return obj.isoformat()
+        if isinstance(obj, dict):
+            return {k: _convert(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [_convert(v) for v in obj]
+        return obj
+
+    payload = _convert(payload)
+
+    await GatewayAPIDriver.send_to_webhook(payload)

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -1,9 +1,22 @@
-from config import bot
+from config import bot, settings
 
 from handlers import *
 
 
+def _ask_code() -> str:
+    print("[!] Telegram requires a login code. Enter it below:")
+    return input('>>> ')
+
+
+def _ask_password() -> str:
+    return input('[!] Enter 2FA password:\n>>> ')
+
+
 if __name__ == '__main__':
-    bot.start()
+    bot.start(
+        phone=settings.TG_PHONE_NUMBER,
+        code_callback=_ask_code,
+        password=_ask_password,
+    )
     print('Bot is running!')
     bot.run_until_disconnected()

--- a/sender/Dockerfile
+++ b/sender/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /sender
 
 COPY ./pyproject.toml /sender/
 COPY ./poetry.lock /sender/
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install
+RUN pip install poetry && poetry config virtualenvs.create false && \
+    poetry install --no-root && \
+    pip install --no-cache-dir -U telethon
 
 COPY ./ /sender

--- a/sender/app/config/bot.py
+++ b/sender/app/config/bot.py
@@ -10,4 +10,4 @@ async def bot_init() -> TelegramClient:
         api_hash=settings.TG_API_HASH,
     )
 
-    return await bot.start(bot_token=settings.TG_BOT_TOKEN)
+    return await bot.start(phone=settings.TG_PHONE_NUMBER)

--- a/sender/app/config/settings.py
+++ b/sender/app/config/settings.py
@@ -1,4 +1,5 @@
 import secrets
+from pathlib import Path
 
 from pydantic import BaseSettings
 
@@ -10,14 +11,15 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str = 'tg-bot-service-sender'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
-    TG_API_ID: str = 'tg-api-id'
+    TG_API_ID: int = 0
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_sender'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
     TG_FILES_CHAT_ID: int = 0
 
     class Config:
+        env_file = Path(__file__).resolve().parents[3] / '.env'
         case_sensitive = True
 
 


### PR DESCRIPTION
## Summary
- ensure login prompts appear directly in compose terminal
- clarify README about entering code and 2FA password
- fix datetime serialization for webhook forwarding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68530cdfc3ac832eb98744cbd87d2439