### PR TITLE
Implement Bot API-style sender API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Telegram API credentials from https://my.telegram.org for a user application
+TG_API_ID=123456
+TG_API_HASH=your_api_hash
+TG_SESSION_NAME=/sessions/tg_userbot
+TG_PHONE_NUMBER=+10000000000  # phone number for login
+X_API_TOKEN=secret-api-key
+WEBHOOK_URL=https://your.webhook.url
+WEBHOOK_API_KEY=secret-api-key
+TG_FILES_CHAT_ID=0
+PUBLIC_BASE_URL=https://userbot.zhito-systems.work

--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ Thumbs.db #thumbnail cache on Windows
 
 # telethon sessions
 tg_session*
+sessions/*.session
+receiver/media/*
+!receiver/media/.gitkeep

--- a/README.md
+++ b/README.md
@@ -18,13 +18,17 @@ Basis for extendable, high-performance Telegram Bot microservice.
 - Logger for API Driver [Native Python Logger] - to monitor and log each request and response. Additionally, keeps logs in files to use with monitoring tools, such as ELK, Prometheus+Grafana, etc.
 
 ### Sender Service
-- Async API [FastAPI] - receive requests from other services. Endpoints:
-    * `/api_v1/send_message` - send plain message to user
-    * `/api_v1/send_multiple_message` - send multiple messages to multiple users
-    * `/api_v1/create_document` - create document on Telegram Servers and receive its ID, to later reuse
-    * `/api_v1/send_document` - send document by Telegram ID
-    * `/api_v1/send_multiple_documents` - send multiple documents to multiple users
-- Sender [Telethon] - Telegram Client that will be triggered to execute some business logic after successful processing of request received by API, in other words to send updates to user.
+- REST API built with FastAPI. Methods mimic the [Telegram Bot API](https://core.telegram.org/bots/api):
+    * `POST /api_v1/sendMessage`
+    * `POST /api_v1/sendPhoto`
+    * `POST /api_v1/sendDocument`
+    * `POST /api_v1/sendAudio`
+    * `POST /api_v1/sendVoice`
+    * `POST /api_v1/sendVideo`
+    * `POST /api_v1/editMessageText`
+    * `POST /api_v1/deleteMessage`
+- Each request must include `x-api-key` header matching `X_API_TOKEN` from `.env`.
+- Sender uses Telethon to act as a user account.
 
 
 ## Whole Service Workflow
@@ -53,6 +57,22 @@ And start up services:
 ```shell
 docker-compose up
 ```
+
+### Configuration
+
+1.  Copy `.env.example` to `.env`, populate your Telegram API credentials, session name, phone number, webhook information and `PUBLIC_BASE_URL`. Keep the file in the repository root next to `docker-compose.yml`.
+2.  Create an empty `sessions/` directory next to the compose file. Docker Compose mounts this path into both services so they share one Telethon session.
+   In your `.env` set `TG_SESSION_NAME=/sessions/tg_userbot` (or any name inside `/sessions`).
+3.  Create a host directory `/srv/filebrowser/userbot_media` and make it publicly available via your web server. Files saved there will be accessible as `{PUBLIC_BASE_URL}/media/<filename>`.
+4.  Docker Compose loads the `.env` file automatically for both services (see `env_file` in `docker-compose.yml`).
+5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
+6.  Run the services with `docker-compose up`. When `receiver` starts for the first time it will prompt for the Telegram code (and 2FA password if enabled).
+   Enter the values directly in the compose terminal. Subsequent runs will reuse the saved session file from `sessions/`.
+7.  Ensure `TG_API_ID` and `TG_API_HASH` are taken from a **user** application created on [my.telegram.org](https://my.telegram.org) and not from a bot. Otherwise login will fail.
+8.  During image build the latest Telethon is installed automatically. If you build images manually, update Telethon with `pip install -U telethon`.
+9.  The `/srv/filebrowser/userbot_media` directory is mounted into the receiver container at `/receiver/media`, so exposing this path allows `media_url` to work correctly.
+
+Use the **sender** service endpoints to send messages from your server to Telegram.
 
 **Sender** service API can be found on http://0.0.0.0:8001 and docs on http://0.0.0.0:8001/docs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,17 +6,23 @@ services:
         build:
             context: ./sender
             dockerfile: Dockerfile
+        env_file:
+          - .env
         ports:
           - 8001:8000
         volumes:
           - ./sender:/sender
+          - ./sessions:/sessions
         tty: true
     receiver:
         command: sh -c "python3 main.py"
         build:
             context: ./receiver
             dockerfile: Dockerfile
+        env_file:
+          - .env
         volumes:
-          - ./receiver:/receiver
+          - ./sessions:/sessions
+          - /srv/filebrowser/userbot_media:/receiver/media
         tty: true
         stdin_open: true

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /receiver
 
 COPY ./pyproject.toml /receiver/
 COPY ./poetry.lock /receiver/
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install
+RUN pip install poetry && poetry config virtualenvs.create false && \
+    poetry install --no-root && \
+    pip install --no-cache-dir -U telethon
 
 COPY ./ /receiver

--- a/receiver/api_driver/driver.py
+++ b/receiver/api_driver/driver.py
@@ -10,8 +10,8 @@ from .logger import gateway_api_driver_logger_init
 
 
 class GatewayAPIDriver:
-    _api_root_url: str = settings.GW_ROOT_URL
-    _api_key: str = settings.GW_API_KEY
+    _webhook_url: str = settings.WEBHOOK_URL
+    _api_key: str = settings.WEBHOOK_API_KEY
 
     logger: logging.Logger = gateway_api_driver_logger_init()
 
@@ -22,27 +22,18 @@ class GatewayAPIDriver:
             'body: {body} error: {error}'
         )
 
-    class Route:
-        USERS: str = '/users'
-
     @classmethod
-    async def _build_url(cls, route: str) -> str:
-        return f'{cls._api_root_url}{route}'
+    async def send_to_webhook(cls, payload: dict) -> httpx.Response:
+        url = cls._webhook_url
+        headers = {
+            'x-api-key': cls._api_key,
+            'Content-Type': 'application/json',
+        }
 
-    @classmethod
-    async def tg_user_create(cls, name: str, chat_id: int) -> httpx.Response:
-        url = await cls._build_url(cls.Route.USERS)
-        headers = {'x-api-key': cls._api_key}
-        data = {'name': name, 'chat_id': chat_id}
-
-        cls._log_request(url, headers, data)
+        cls._log_request(url, headers, payload)
 
         async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                url,
-                headers=headers,
-                data=data,
-            )
+            resp = await client.post(url, headers=headers, json=payload)
 
         try:
             resp_body = resp.json()

--- a/receiver/config/bot.py
+++ b/receiver/config/bot.py
@@ -6,4 +6,7 @@ bot = TelegramClient(
     session=settings.TG_SESSION_NAME,
     api_id=settings.TG_API_ID,
     api_hash=settings.TG_API_HASH,
-).start(bot_token=settings.TG_BOT_TOKEN)
+)
+
+# `start` is called explicitly in `receiver/main.py` so that the login prompts
+# appear in the container's console when the service launches.

--- a/receiver/config/settings.py
+++ b/receiver/config/settings.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 
 from pydantic import BaseSettings
 
@@ -6,13 +7,15 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     PROJECT_NAME: str = 'tg-bot-service-receiver'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
-    TG_API_ID: str = 'tg-api-id'
+    TG_API_ID: int = 0
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_receiver'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
-    GW_ROOT_URL: str = 'https://some.host'
-    GW_API_KEY: str = 'secret-api-key'
+    WEBHOOK_URL: str = 'https://some.host/webhook'
+    WEBHOOK_API_KEY: str = 'secret-api-key'
+    PUBLIC_BASE_URL: str = 'https://example.com'
+
 
     LOGS_DIR: str = 'logs/'
 
@@ -25,6 +28,7 @@ class Settings(BaseSettings):
         )
 
     class Config:
+        env_file = Path(__file__).resolve().parents[2] / '.env'
         case_sensitive = True
 
 

--- a/receiver/handlers/__init__.py
+++ b/receiver/handlers/__init__.py
@@ -1,1 +1,2 @@
 from .conversations import familiarize_conv_handler
+from .webhook_forwarder import forward_all_messages

--- a/receiver/handlers/webhook_forwarder.py
+++ b/receiver/handlers/webhook_forwarder.py
@@ -1,0 +1,79 @@
+from datetime import date, datetime
+
+from pathlib import Path
+
+from telethon import events
+from telethon.utils import pack_bot_file_id
+
+from api_driver import GatewayAPIDriver
+from config import bot, settings
+
+
+MEDIA_DIR = Path(__file__).resolve().parents[1] / 'media'
+
+
+@bot.on(events.NewMessage)
+async def forward_all_messages(event) -> None:
+    """Forward every incoming message to the configured webhook."""
+    if event.out:
+        return
+
+    sender = await event.get_sender()
+
+    user_info = {
+        "id": sender.id,
+        "first_name": sender.first_name,
+        "last_name": sender.last_name,
+        "username": sender.username,
+        "language_code": getattr(sender, "lang_code", None),
+        "phone_number": getattr(sender, "phone", None),
+    }
+
+    msg = event.message
+
+    media = None
+    media_url = None
+    if msg.media:
+        media_type = None
+        if msg.voice:
+            media_type = "voice"
+        elif msg.video:
+            media_type = "video"
+        elif msg.photo:
+            media_type = "photo"
+        elif msg.document:
+            media_type = "document"
+        else:
+            media_type = msg.media.__class__.__name__.lower()
+
+        try:
+            file_id = pack_bot_file_id(msg.media)
+        except Exception:
+            file_id = None
+
+        ext = msg.file.ext or '.bin'
+        if not ext.startswith('.'):
+            ext = '.' + ext
+        filename = f"{msg.id}_{media_type}{ext}"
+        MEDIA_DIR.mkdir(exist_ok=True)
+        await msg.download_media(file=MEDIA_DIR / filename)
+        media_url = f"{settings.PUBLIC_BASE_URL.rstrip('/')}/media/{filename}"
+
+        media = {"type": media_type, "file_id": file_id}
+
+    message_dict = {
+        "message_id": msg.id,
+        "chat": {"id": event.chat_id},
+        "date": msg.date.isoformat(),
+        "text": msg.message,
+        "media": media,
+        "media_url": media_url,
+        "from": user_info,
+    }
+
+    payload = {
+        "account_phone_number": settings.TG_PHONE_NUMBER,
+        "message": message_dict,
+    }
+
+    await GatewayAPIDriver.send_to_webhook(payload)

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -1,9 +1,22 @@
-from config import bot
+from config import bot, settings
 
 from handlers import *
 
 
+def _ask_code() -> str:
+    print("[!] Telegram requires a login code. Enter it below:")
+    return input('>>> ')
+
+
+def _ask_password() -> str:
+    return input('[!] Enter 2FA password:\n>>> ')
+
+
 if __name__ == '__main__':
-    bot.start()
+    bot.start(
+        phone=settings.TG_PHONE_NUMBER,
+        code_callback=_ask_code,
+        password=_ask_password,
+    )
     print('Bot is running!')
     bot.run_until_disconnected()

--- a/sender/Dockerfile
+++ b/sender/Dockerfile
@@ -8,6 +8,8 @@ WORKDIR /sender
 
 COPY ./pyproject.toml /sender/
 COPY ./poetry.lock /sender/
-RUN pip install poetry && poetry config virtualenvs.create false && poetry install
+RUN pip install poetry && poetry config virtualenvs.create false && \
+    poetry install --no-root && \
+    pip install --no-cache-dir -U telethon
 
 COPY ./ /sender

--- a/sender/app/api/deps.py
+++ b/sender/app/api/deps.py
@@ -1,0 +1,7 @@
+from fastapi import Header, HTTPException, status
+
+from app.config import settings
+
+async def verify_api_key(x_api_key: str = Header(...)) -> None:
+    if x_api_key != settings.X_API_TOKEN:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid API key")

--- a/sender/app/api/v1/api.py
+++ b/sender/app/api/v1/api.py
@@ -3,4 +3,4 @@ from fastapi import APIRouter
 from app.api.v1.endpoints.routes import router
 
 api_router = APIRouter()
-api_router.include_router(router, tags=['hello'])
+api_router.include_router(router, tags=["bot"])

--- a/sender/app/api/v1/endpoints/routes.py
+++ b/sender/app/api/v1/endpoints/routes.py
@@ -1,53 +1,110 @@
-from typing import Optional, NoReturn
+from typing import Optional
+import base64
+import mimetypes
+import uuid
+from pathlib import Path
 
-from fastapi import APIRouter, status, UploadFile, File
+import httpx
+from fastapi import APIRouter, status, Depends, HTTPException
 
 from app import schemas
-from app.services import (
-    document_send,
-    document_send_multiple,
-    message_send,
-    message_send_multiple,
-    tg_document_create,
-)
+from app.api.deps import verify_api_key
+from app.config import bot_init
 
-router = APIRouter()
+TMP_DIR = Path("/tmp/userbot-api")
+TMP_DIR.mkdir(parents=True, exist_ok=True)
+
+router = APIRouter(dependencies=[Depends(verify_api_key)])
 
 
-@router.post('/send_message', status_code=status.HTTP_200_OK)
-async def send_plain_message(message: schemas.PlainMessageSend) -> Optional[NoReturn]:
-    # TODO: consider handling exception on unknown PEER_ID
-    await message_send(message)
-    return
+def _serialize_message(msg) -> dict:
+    return {
+        "message_id": msg.id,
+        "chat": {"id": msg.chat_id},
+        "date": msg.date.isoformat(),
+        "text": msg.text or msg.message,
+    }
 
 
-@router.post('/send_multiple_messages', status_code=status.HTTP_200_OK)
-async def send_multiple_messages(messages: list[schemas.PlainMessageSend]) -> Optional[NoReturn]:
-    # TODO: consider handling TG exceptions related to Timeout, TooMuchRequests, etc
-    await message_send_multiple(messages)
-    return
+async def _download_file(src: str) -> Path:
+    if src.startswith("http://") or src.startswith("https://"):
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(src)
+            resp.raise_for_status()
+            data = resp.content
+            ext = mimetypes.guess_extension(resp.headers.get("content-type", "")) or ".bin"
+    else:
+        if src.startswith("data:") and ";base64," in src:
+            header, b64 = src.split(",", 1)
+            mime = header[5: header.index(";")]
+            ext = mimetypes.guess_extension(mime) or ".bin"
+            data = base64.b64decode(b64)
+        else:
+            data = base64.b64decode(src)
+            ext = ".bin"
+    filename = TMP_DIR / f"{uuid.uuid4().hex}{ext}"
+    filename.write_bytes(data)
+    return filename
 
 
-@router.post(
-        '/create_document',
-        response_model=schemas.DocumentCreate,
-        status_code=status.HTTP_201_CREATED,
-)
-async def create_document(document: UploadFile = File(...))-> dict[str, str]:
-    # TODO: consider handling TG exceptions related to Timeout, FileSize, etc
-    doc_created = await tg_document_create(document)
-    return doc_created
+@router.post("/sendMessage")
+async def send_message(payload: schemas.SendMessage):
+    async with await bot_init() as bot:
+        msg = await bot.send_message(payload.chat_id, payload.text, parse_mode=payload.parse_mode)
+    return {"ok": True, "result": _serialize_message(msg)}
 
 
-@router.post('/send_document', status_code=status.HTTP_200_OK)
-async def send_document(message: schemas.DocumentSend) -> Optional[NoReturn]:
-    # TODO: handle potential exceptions
-    await document_send(message)
-    return
+async def _send_media(chat_id: int, file_src: str, caption: Optional[str]) -> dict:
+    file_path = await _download_file(file_src)
+    async with await bot_init() as bot:
+        msg = await bot.send_file(chat_id, file_path, caption=caption)
+    return _serialize_message(msg) | {"file_name": file_path.name}
 
 
-@router.post('/send_multiple_documents', status_code=status.HTTP_200_OK)
-async def send_multiple_documents(messages: list[schemas.DocumentSend]) -> Optional[NoReturn]:
-    # TODO: handle potential exceptions
-    await document_send_multiple(messages)
-    return
+@router.post("/sendPhoto")
+async def send_photo(payload: schemas.SendPhoto):
+    msg = await _send_media(payload.chat_id, payload.photo, payload.caption)
+    msg["file_type"] = "photo"
+    return {"ok": True, "result": msg}
+
+
+@router.post("/sendDocument")
+async def send_document(payload: schemas.SendDocument):
+    msg = await _send_media(payload.chat_id, payload.document, payload.caption)
+    msg["file_type"] = "document"
+    return {"ok": True, "result": msg}
+
+
+@router.post("/sendAudio")
+async def send_audio(payload: schemas.SendAudio):
+    msg = await _send_media(payload.chat_id, payload.audio, payload.caption)
+    msg["file_type"] = "audio"
+    return {"ok": True, "result": msg}
+
+
+@router.post("/sendVoice")
+async def send_voice(payload: schemas.SendVoice):
+    msg = await _send_media(payload.chat_id, payload.voice, payload.caption)
+    msg["file_type"] = "voice"
+    return {"ok": True, "result": msg}
+
+
+@router.post("/sendVideo")
+async def send_video(payload: schemas.SendVideo):
+    msg = await _send_media(payload.chat_id, payload.video, payload.caption)
+    msg["file_type"] = "video"
+    return {"ok": True, "result": msg}
+
+
+@router.post("/editMessageText")
+async def edit_message_text(payload: schemas.EditMessageText):
+    async with await bot_init() as bot:
+        msg = await bot.edit_message(entity=payload.chat_id, message=payload.message_id, text=payload.text, parse_mode=payload.parse_mode)
+    return {"ok": True, "result": _serialize_message(msg)}
+
+
+@router.post("/deleteMessage")
+async def delete_message(payload: schemas.DeleteMessage):
+    async with await bot_init() as bot:
+        await bot.delete_messages(entity=payload.chat_id, message_ids=payload.message_id)
+    return {"ok": True, "result": "Message deleted"}

--- a/sender/app/config/bot.py
+++ b/sender/app/config/bot.py
@@ -10,4 +10,4 @@ async def bot_init() -> TelegramClient:
         api_hash=settings.TG_API_HASH,
     )
 
-    return await bot.start(bot_token=settings.TG_BOT_TOKEN)
+    return await bot.start(phone=settings.TG_PHONE_NUMBER)

--- a/sender/app/config/settings.py
+++ b/sender/app/config/settings.py
@@ -1,4 +1,5 @@
 import secrets
+from pathlib import Path
 
 from pydantic import BaseSettings
 
@@ -10,14 +11,15 @@ class Settings(BaseSettings):
 
     PROJECT_NAME: str = 'tg-bot-service-sender'
 
-    TG_BOT_TOKEN: str = 'tg-bot-token'
-    TG_API_ID: str = 'tg-api-id'
+    TG_API_ID: int = 0
     TG_API_HASH: str = 'tg-api-hash'
     TG_SESSION_NAME: str = 'tg_session_sender'
+    TG_PHONE_NUMBER: str = '+10000000000'
 
     TG_FILES_CHAT_ID: int = 0
 
     class Config:
+        env_file = Path(__file__).resolve().parents[3] / '.env'
         case_sensitive = True
 
 

--- a/sender/app/schemas/__init__.py
+++ b/sender/app/schemas/__init__.py
@@ -1,1 +1,5 @@
 from .user import PlainMessageSend, DocumentCreate, DocumentSend
+from .bot import (
+    SendMessage, SendPhoto, SendDocument, SendAudio,
+    SendVoice, SendVideo, EditMessageText, DeleteMessage
+)

--- a/sender/app/schemas/bot.py
+++ b/sender/app/schemas/bot.py
@@ -1,0 +1,42 @@
+from pydantic import BaseModel
+from typing import Optional
+
+class SendMessage(BaseModel):
+    chat_id: int
+    text: str
+    parse_mode: Optional[str] = None
+
+class SendPhoto(BaseModel):
+    chat_id: int
+    photo: str
+    caption: Optional[str] = None
+
+class SendDocument(BaseModel):
+    chat_id: int
+    document: str
+    caption: Optional[str] = None
+
+class SendAudio(BaseModel):
+    chat_id: int
+    audio: str
+    caption: Optional[str] = None
+
+class SendVoice(BaseModel):
+    chat_id: int
+    voice: str
+    caption: Optional[str] = None
+
+class SendVideo(BaseModel):
+    chat_id: int
+    video: str
+    caption: Optional[str] = None
+
+class EditMessageText(BaseModel):
+    chat_id: int
+    message_id: int
+    text: str
+    parse_mode: Optional[str] = None
+
+class DeleteMessage(BaseModel):
+    chat_id: int
+    message_id: int


### PR DESCRIPTION
## Summary
- document new API endpoints in README
- add API key config in `.env.example`
- require `x-api-key` header via new dependency
- provide Bot API-like endpoints for sending and editing messages using a userbot
- mount media folder for receiver
- document shared media path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68530cdfc3ac832eb98744cbd87d2439