### PR TITLE
Add reply message support in receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,41 @@ Use the **sender** service endpoints to send messages from your server to Telegr
 
 **Sender** service API can be found on http://0.0.0.0:8001 and docs on http://0.0.0.0:8001/docs
 
+### Example webhook payload
+
+When a user replies to a message, the receiver forwards the update to the configured webhook with the following structure:
+
+```json
+{
+  "account_phone_number": "+10000000000",
+  "message": {
+    "message_id": 2345,
+    "chat": {"id": 1111111},
+    "date": "2023-01-01T12:00:00",
+    "text": "Це відповідь",
+    "media": null,
+    "media_url": null,
+    "from": {
+      "id": 777000,
+      "first_name": "User",
+      "last_name": null,
+      "username": "user",
+      "language_code": "en",
+      "phone_number": null
+    },
+    "reply_to_message": {
+      "message_id": 1234,
+      "text": "Оригінальне повідомлення",
+      "media_url": "https://example.com/media/1234_photo.jpg",
+      "media_type": "photo",
+      "sender_id": 1111111,
+      "sender_name": "Other",
+      "date": "2023-01-01T11:59:00"
+    }
+  }
+}
+```
+
 
 ## Enhancement, contribution, and feedback
 Any feedback or contribution to the project is eagerly welcomed. Just create an issue or contact me on ki.xbozz@gmail.com.

--- a/receiver/handlers/webhook_forwarder.py
+++ b/receiver/handlers/webhook_forwarder.py
@@ -61,6 +61,43 @@ async def forward_all_messages(event) -> None:
 
         media = {"type": media_type, "file_id": file_id}
 
+    reply_to_message = None
+    if event.is_reply:
+        reply_msg = await event.get_reply_message()
+        reply_sender = await reply_msg.get_sender()
+
+        r_media_type = None
+        r_media_url = None
+        if reply_msg.media:
+            if reply_msg.voice:
+                r_media_type = "voice"
+            elif reply_msg.video:
+                r_media_type = "video"
+            elif reply_msg.photo:
+                r_media_type = "photo"
+            elif reply_msg.document:
+                r_media_type = "document"
+            else:
+                r_media_type = reply_msg.media.__class__.__name__.lower()
+
+            ext = reply_msg.file.ext or '.bin'
+            if not ext.startswith('.'):
+                ext = '.' + ext
+            filename = f"{reply_msg.id}_{r_media_type}{ext}"
+            MEDIA_DIR.mkdir(exist_ok=True)
+            await reply_msg.download_media(file=MEDIA_DIR / filename)
+            r_media_url = f"{settings.PUBLIC_BASE_URL.rstrip('/')}/media/{filename}"
+
+        reply_to_message = {
+            "message_id": reply_msg.id,
+            "text": reply_msg.message,
+            "media_url": r_media_url,
+            "media_type": r_media_type,
+            "sender_id": reply_sender.id,
+            "sender_name": reply_sender.first_name,
+            "date": reply_msg.date.isoformat(),
+        }
+
     message_dict = {
         "message_id": msg.id,
         "chat": {"id": event.chat_id},
@@ -69,6 +106,7 @@ async def forward_all_messages(event) -> None:
         "media": media,
         "media_url": media_url,
         "from": user_info,
+        "reply_to_message": reply_to_message,
     }
 
     payload = {


### PR DESCRIPTION
## Summary
- include reply message info in webhook payloads
- save media from replied message and expose via `media_url`
- document webhook payload example with `reply_to_message`

## Testing
- `python -m py_compile receiver/handlers/webhook_forwarder.py`
- `python -m compileall -q receiver`

------
https://chatgpt.com/codex/tasks/task_e_685d44fa5f84832e9d1f1d4cc954671f