### PR TITLE
Add receiver media server and public media links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,5 +8,8 @@ WEBHOOK_URL=https://your.webhook.url
 WEBHOOK_API_KEY=secret-api-key
 TG_FILES_CHAT_ID=0
 PUBLIC_BASE_URL=https://userbot.zhito-systems.work
+# Host and port used for public media links
+PUBLIC_MEDIA_HOST=userbot.zhito-systems.work
+PUBLIC_MEDIA_PORT=8181
 # Media URLs will be served as:
-# {PUBLIC_BASE_URL}/media/<file_name>
+# http://<PUBLIC_MEDIA_HOST>:<PUBLIC_MEDIA_PORT>/media/<file_name>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,10 +13,10 @@ services:
         volumes:
           - ./sender:/sender
           - ./sessions:/sessions
-          - /srv/filebrowser/userbot_media:/media:ro
+          - ./receiver/media:/media:ro
         tty: true
     receiver:
-        command: sh -c "python3 main.py"
+        command: sh -c "python3 main.py & python3 media_server.py"
         build:
             context: .
             dockerfile: receiver/Dockerfile
@@ -24,6 +24,8 @@ services:
           - .env
         volumes:
           - ./sessions:/sessions
-          - /srv/filebrowser/userbot_media:/receiver/media
+          - ./receiver/media:/receiver/media
+        ports:
+          - 8181:8082
         tty: true
         stdin_open: true

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -10,6 +10,7 @@ COPY ./receiver/pyproject.toml /receiver/
 COPY ./receiver/poetry.lock /receiver/
 RUN pip install poetry && poetry config virtualenvs.create false && \
     poetry install --no-root && \
-    pip install --no-cache-dir -U telethon
+    pip install --no-cache-dir -U telethon && \
+    pip install flask
 
 COPY ./receiver /receiver

--- a/receiver/config/settings.py
+++ b/receiver/config/settings.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     WEBHOOK_URL: str = 'https://some.host/webhook'
     WEBHOOK_API_KEY: str = 'secret-api-key'
     PUBLIC_BASE_URL: str = 'https://example.com'
+    PUBLIC_MEDIA_HOST: str = 'userbot.zhito-systems.work'
+    PUBLIC_MEDIA_PORT: int = 8181
 
 
     LOGS_DIR: str = 'logs/'

--- a/receiver/handlers/webhook_forwarder.py
+++ b/receiver/handlers/webhook_forwarder.py
@@ -57,7 +57,9 @@ async def forward_all_messages(event) -> None:
         filename = f"{msg.id}_{media_type}{ext}"
         MEDIA_DIR.mkdir(exist_ok=True)
         await msg.download_media(file=MEDIA_DIR / filename)
-        media_url = f"{settings.PUBLIC_BASE_URL.rstrip('/')}/media/{filename}"
+        media_url = (
+            f"http://{settings.PUBLIC_MEDIA_HOST}:{settings.PUBLIC_MEDIA_PORT}/media/{filename}"
+        )
 
         media = {"type": media_type, "file_id": file_id}
 
@@ -86,7 +88,9 @@ async def forward_all_messages(event) -> None:
             filename = f"{reply_msg.id}_{r_media_type}{ext}"
             MEDIA_DIR.mkdir(exist_ok=True)
             await reply_msg.download_media(file=MEDIA_DIR / filename)
-            r_media_url = f"{settings.PUBLIC_BASE_URL.rstrip('/')}/media/{filename}"
+            r_media_url = (
+                f"http://{settings.PUBLIC_MEDIA_HOST}:{settings.PUBLIC_MEDIA_PORT}/media/{filename}"
+            )
 
         reply_to_message = {
             "message_id": reply_msg.id,

--- a/receiver/media_server.py
+++ b/receiver/media_server.py
@@ -1,0 +1,13 @@
+from flask import Flask, send_from_directory
+from pathlib import Path
+
+app = Flask(__name__)
+
+MEDIA_DIR = Path(__file__).resolve().parent / 'media'
+
+@app.route('/media/<path:filename>')
+def serve_media(filename: str):
+    return send_from_directory(MEDIA_DIR, filename)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8082)


### PR DESCRIPTION
## Summary
- expose downloaded media through Flask in receiver
- start media server alongside receiver in Docker Compose
- add PUBLIC_MEDIA_HOST/PUBLIC_MEDIA_PORT env vars
- mount receiver media folder and publish it on port 8181
- document the new setup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e8595c34c832eb2ff269c59fcf506