### PR TITLE
Implement public media serving and config updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,5 +147,5 @@ Thumbs.db #thumbnail cache on Windows
 # telethon sessions
 tg_session*
 sessions/*.session
-receiver/media/*
-!receiver/media/.gitkeep
+userbot_media/*
+!userbot_media/.gitkeep

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
 1.  Copy `.env.example` to `.env`, populate your Telegram API credentials, session name, phone number, webhook information and public domain settings (`PUBLIC_MEDIA_HOST`, `PUBLIC_MEDIA_PORT`). Keep the file in the repository root next to `docker-compose.yml`.
 2.  Create an empty `sessions/` directory next to the compose file. Docker Compose mounts this path into both services so they share one Telethon session.
    In your `.env` set `TG_SESSION_NAME=/sessions/tg_userbot` (or any name inside `/sessions`).
-3.  Ensure the `receiver/media` directory exists. Docker Compose mounts this path
+3.  Ensure the `userbot_media` directory exists. Docker Compose mounts this path
    into both services so that downloaded files persist and can be served over HTTP
    at `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_MEDIA_PORT>/media/<filename>`.
 4.  Docker Compose loads the `.env` file automatically for both services (see

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
     sender:
-        command: sh -c "uvicorn app.main:app --reload --host 0.0.0.0"
+        command: sh -c "uvicorn app.main:app --host 0.0.0.0 --port 8000"
         build:
             context: ./sender
             dockerfile: Dockerfile
@@ -13,7 +13,7 @@ services:
         volumes:
           - ./sender:/sender
           - ./sessions:/sessions
-          - ./receiver/media:/media:ro
+          - ./userbot_media:/media:ro
         tty: true
     receiver:
         command: sh -c "python3 main.py & python3 media_server.py"
@@ -24,8 +24,8 @@ services:
           - .env
         volumes:
           - ./sessions:/sessions
-          - ./receiver/media:/receiver/media
+          - ./userbot_media:/receiver/media
         ports:
-          - 8181:8082
+          - 8181:8181
         tty: true
         stdin_open: true

--- a/receiver/media_server.py
+++ b/receiver/media_server.py
@@ -1,13 +1,12 @@
 from flask import Flask, send_from_directory
-from pathlib import Path
+import os
 
 app = Flask(__name__)
-
-MEDIA_DIR = Path(__file__).resolve().parent / 'media'
+MEDIA_DIR = "media"
 
 @app.route('/media/<path:filename>')
 def serve_media(filename: str):
     return send_from_directory(MEDIA_DIR, filename)
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=8082)
+    app.run(host='0.0.0.0', port=8181)

--- a/receiver/pyproject.toml
+++ b/receiver/pyproject.toml
@@ -5,12 +5,14 @@ description = ""
 authors = ["raisultan <ki.xbozz@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "3.9.0"
+python = ">=3.9,<4.0"
 Telethon = "1.21.1"
 pydantic = "1.8.1"
 httpx = "0.17.1"
 cryptg = "^0.2.post2"
 Pillow = "8.2.0"
+aiofiles = "^23.2.1"
+flask = "^3.0.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/sender/app/api/v1/endpoints/routes.py
+++ b/sender/app/api/v1/endpoints/routes.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, status, Depends, HTTPException
 
 from app import schemas
 from app.api.deps import verify_api_key
-from app.config import bot_init
+from app.config import bot_init, settings
 
 TMP_DIR = Path("/tmp/userbot-api")
 TMP_DIR.mkdir(parents=True, exist_ok=True)
@@ -58,7 +58,10 @@ async def _send_media(chat_id: int, file_src: str, caption: Optional[str]) -> di
     file_path = await _download_file(file_src)
     async with await bot_init() as bot:
         msg = await bot.send_file(chat_id, file_path, caption=caption)
-    return _serialize_message(msg) | {"file_name": file_path.name}
+    return _serialize_message(msg) | {
+        "file_name": file_path.name,
+        "file_url": f"{settings.PUBLIC_BASE_URL}/media/{file_path.name}"
+    }
 
 
 @router.post("/sendPhoto")

--- a/sender/app/config/settings.py
+++ b/sender/app/config/settings.py
@@ -19,6 +19,7 @@ class Settings(BaseSettings):
     TG_FILES_CHAT_ID: int = 0
 
     MEDIA_DIR: str = "/media"
+    PUBLIC_BASE_URL: str = "https://example.com"
 
     class Config:
         env_file = Path(__file__).resolve().parents[3] / '.env'

--- a/sender/pyproject.toml
+++ b/sender/pyproject.toml
@@ -5,7 +5,7 @@ description = ""
 authors = ["raisultan <ki.xbozz@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "3.9.0"
+python = ">=3.9,<4.0"
 uvicorn = "0.12.3"
 fastapi = "0.62.0"
 Telethon = "1.21.1"
@@ -14,6 +14,8 @@ python-multipart = "^0.0.5"
 asyncio = "3.4.3"
 cryptg = "0.2.post2"
 Pillow = "8.2.0"
+aiofiles = "^23.2.1"
+flask = "^3.0.0"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION
## Summary
- mount a shared `userbot_media` folder for both services
- adjust Docker setup for userbot and Flask server
- add `PUBLIC_BASE_URL` config in sender
- return public links for sent media
- serve media on port `8181` with Flask

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec8a9a554832e8ad2836fecb0c61e