### PR TITLE
Improve docker compose and env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,24 @@
 # Telegram Bot Microservice
 Basis for extendable, high-performance Telegram Bot microservice.
 
+## ⚡ Швидкий старт
+1. Клонуйте репозиторій та перейдіть у каталог проекту
+   ```bash
+   git clone <repo-url> && cd tg-bot-service
+   ```
+2. Скопіюйте `.env.example` у `.env` та заповніть свої дані
+   ```bash
+   cp .env.example .env
+   ```
+3. Створіть каталоги для сесій та медіа
+   ```bash
+   mkdir -p sessions receiver/media
+   ```
+4. Запустіть сервіси
+   ```bash
+   docker compose up -d --build
+   ```
+5. Перевірте API відправника на [http://localhost:8001/docs](http://localhost:8001/docs)
 
 ## Tech Stack
 - FastAPI

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,32 @@
-version: '3.8'
-
 services:
-    sender:
-        command: sh -c "uvicorn app.main:app --host 0.0.0.0 --port 8000"
-        build:
-            context: ./sender
-            dockerfile: Dockerfile
-        env_file:
-          - .env
-        ports:
-          - 8001:8000
-        volumes:
-          - ./sender:/sender
-          - ./sessions:/sessions
-          - ./userbot_media:/media:ro
-        tty: true
-    receiver:
-        command: sh -c "python3 main.py & python3 media_server.py"
-        build:
-            context: .
-            dockerfile: receiver/Dockerfile
-        env_file:
-          - .env
-        volumes:
-          - ./sessions:/sessions
-          - ./userbot_media:/receiver/media
-        ports:
-          - 8181:8181
-        tty: true
-        stdin_open: true
+  sender:
+    build:
+      context: ./sender
+    command: uvicorn app.main:app --reload --host 0.0.0.0 --port 8000
+    ports:
+      - 8001:8000
+    env_file:
+      - .env
+    volumes:
+      - ./sender:/sender
+      - ./sessions:/sessions
+      - ./receiver/media:/media:ro
+    tty: true
+    restart: unless-stopped
+
+  receiver:
+    build:
+      context: ./receiver
+    command: sh -c "python3 main.py & python3 media_server.py"
+    ports:
+      - 8181:8181
+    env_file:
+      - .env
+    volumes:
+      - ./sessions:/sessions
+      - ./receiver/media:/receiver/media
+    tty: true
+    stdin_open: true
+    restart: unless-stopped
+    depends_on:
+      - sender

--- a/sender/Dockerfile
+++ b/sender/Dockerfile
@@ -8,8 +8,11 @@ WORKDIR /sender
 
 COPY ./pyproject.toml /sender/
 COPY ./poetry.lock /sender/
-RUN pip install poetry && poetry config virtualenvs.create false && \
+RUN pip install poetry && \
+    poetry config virtualenvs.create false && \
     poetry install --no-root && \
     pip install --no-cache-dir -U telethon
 
 COPY ./ /sender
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/sender/pyproject.toml
+++ b/sender/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["raisultan <ki.xbozz@gmail.com>"]
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-uvicorn = "0.12.3"
+uvicorn = "^0.23.2"
 fastapi = "0.62.0"
 Telethon = "1.21.1"
 httpx = "0.17.1"


### PR DESCRIPTION
## Summary
- restore detailed example environment variables
- use original port mappings in docker-compose
- update sender CMD to expose port 8000

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `docker compose run --rm sender poetry lock` *(fails: command not found)*
- `poetry lock` *(fails: Poetry could not find a pyproject.toml file)*

------
https://chatgpt.com/codex/tasks/task_e_685f82971dec832e9a8da9a918992e56