### PR TITLE
Fix poetry lock error in Docker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Root directory has docker-compose file through which whole microservice can be s
 ```shell
 docker-compose build
 ```
+The Dockerfiles run `poetry install` during build and automatically generate `poetry.lock` inside the containers. This prevents errors about a missing or outdated lock file when you clone the repository.
 And start up services:
 ```shell
 docker-compose up

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -7,7 +7,6 @@ RUN mkdir /receiver && apt-get update
 WORKDIR /receiver
 
 COPY ./receiver/pyproject.toml /receiver/
-COPY ./receiver/poetry.lock /receiver/
 RUN pip install poetry && poetry config virtualenvs.create false && \
     poetry install --no-root && \
     pip install --no-cache-dir -U telethon && \

--- a/sender/Dockerfile
+++ b/sender/Dockerfile
@@ -7,7 +7,6 @@ RUN mkdir /sender && apt-get update
 WORKDIR /sender
 
 COPY ./pyproject.toml /sender/
-COPY ./poetry.lock /sender/
 RUN pip install poetry && poetry config virtualenvs.create false && \
     poetry install --no-root && \
     pip install --no-cache-dir -U telethon


### PR DESCRIPTION
## Summary
- generate the lock file inside Docker images
- document that `poetry install` runs during image build

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685fa5c9e6a0832eb6bf70e4cf6f9485