### PR TITLE
Add init_session.py for login

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
 4.  Docker Compose loads the `.env` file automatically for both services (see
    `env_file` in `docker-compose.yml`).
 5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
-6.  Run the services with `docker-compose up`. When `receiver` starts for the first time it will prompt for the Telegram code (and 2FA password if enabled).
-   Enter the values directly in the compose terminal. Subsequent runs will reuse the saved session file from `sessions/`.
-7.  Ensure `TG_API_ID` and `TG_API_HASH` are taken from a **user** application created on [my.telegram.org](https://my.telegram.org) and not from a bot. Otherwise login will fail.
-8.  During image build the latest Telethon is installed automatically. If you build images manually, update Telethon with `pip install -U telethon`.
-9.  Media files are served directly by the receiver service on port `8181`, making
+6.  Run `python init_session.py` once locally to create the Telegram session. The
+   script reads credentials from `.env` and saves the session file inside
+   `sessions/`.
+7.  Start the services with `docker-compose up`. They will reuse the saved
+   session file without prompting for the code again.
+8.  Ensure `TG_API_ID` and `TG_API_HASH` are taken from a **user** application created on [my.telegram.org](https://my.telegram.org) and not from a bot. Otherwise login will fail.
+9.  During image build the latest Telethon is installed automatically. If you build images manually, update Telethon with `pip install -U telethon`.
+10.  Media files are served directly by the receiver service on port `8181`, making
    any downloaded files reachable as
    `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_MEDIA_PORT>/media/<filename>` without any
    extra web server.

--- a/init_session.py
+++ b/init_session.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import os
+
+from telethon import TelegramClient
+
+
+def load_env(path: Path) -> None:
+    if not path.exists():
+        return
+    with path.open() as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith('#') or '=' not in line:
+                continue
+            key, _, value = line.partition('=')
+            os.environ.setdefault(key, value)
+
+
+def get_session_path(raw_path: str) -> Path:
+    path = Path(raw_path)
+    if path.is_absolute():
+        if path.parts[:2] == ('', 'sessions'):
+            path = Path('sessions') / path.name
+    return path
+
+
+def main() -> None:
+    load_env(Path('.env'))
+    api_id = int(os.environ['TG_API_ID'])
+    api_hash = os.environ['TG_API_HASH']
+    phone = os.environ['TG_PHONE_NUMBER']
+    session_var = os.environ.get('TG_SESSION_NAME', 'tg_userbot')
+    session_path = get_session_path(session_var)
+    session_path.parent.mkdir(parents=True, exist_ok=True)
+
+    client = TelegramClient(str(session_path), api_id, api_hash)
+    client.start(phone=phone)
+    print(f'Session saved to {session_path.with_suffix(".session")}')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `init_session.py` to create Telethon session outside Docker
- document session initialization in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fc7a4abf0832ea333d8ff146d7c5f