### PR TITLE
Improve session reuse handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,14 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
 4.  Docker Compose loads the `.env` file automatically for both services (see
    `env_file` in `docker-compose.yml`).
 5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
-6.  Run `python init_session.py` once locally to create the Telegram session. The
-   script reads credentials from `.env` and saves the session file inside
-   `sessions/`.
+6.  Run `python init_session.py` once outside of Docker to create the Telegram
+    session.  The script reads credentials from `.env` and stores the session
+    file inside `sessions/`.  When executed locally the script automatically
+    rewrites the `/sessions/<name>` path from the environment to the local
+    `sessions/` directory so the file is visible to the containers.
 7.  Start the services with `docker-compose up`. They will reuse the saved
-   session file without prompting for the code again.
+    session file without prompting for the code again.  If the file is missing
+    the receiver will exit with a helpful message.
 8.  Ensure `TG_API_ID` and `TG_API_HASH` are taken from a **user** application created on [my.telegram.org](https://my.telegram.org) and not from a bot. Otherwise login will fail.
 9.  During image build the latest Telethon is installed automatically. If you build images manually, update Telethon with `pip install -U telethon`.
 10.  Media files are served directly by the receiver service on port `8181`, making

--- a/init_session.py
+++ b/init_session.py
@@ -17,10 +17,23 @@ def load_env(path: Path) -> None:
 
 
 def get_session_path(raw_path: str) -> Path:
+    """Return a path for the session file.
+
+    When executed outside of the Docker container the environment variable is
+    typically set to ``/sessions/<name>`` which does not exist locally.  In this
+    case we store the file inside the repository's ``sessions/`` directory so it
+    gets mounted into the container.  When the ``/sessions`` directory exists
+    (inside the container) the path is used as-is.
+    """
+
     path = Path(raw_path)
-    if path.is_absolute():
-        if path.parts[:2] == ('', 'sessions'):
+
+    if path.is_absolute() and path.parts[:2] == ('/', 'sessions'):
+        # If running locally ``/sessions`` won't exist.  Save the file into the
+        # repository's sessions folder instead so Docker can mount it.
+        if not Path('/sessions').exists():
             path = Path('sessions') / path.name
+
     return path
 
 

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from config import bot, settings
 
 from handlers import *
@@ -13,6 +15,11 @@ def _ask_password() -> str:
 
 
 if __name__ == '__main__':
+    session_file = Path(settings.TG_SESSION_NAME).with_suffix('.session')
+    if not session_file.exists():
+        print(f'[!] Session file {session_file} not found. Run init_session.py first.')
+        raise SystemExit(1)
+
     bot.start(
         phone=settings.TG_PHONE_NUMBER,
         code_callback=_ask_code,


### PR DESCRIPTION
## Summary
- adjust `init_session.py` to correctly map `/sessions` when running locally
- exit receiver if the session file is missing
- document session initialisation and reuse in README

## Testing
- `python3 -m py_compile init_session.py receiver/main.py`

------
https://chatgpt.com/codex/tasks/task_e_685fd4c740d0832ebbb11daa06044bbb