### PR TITLE
Fix receiver session reuse

### DIFF
--- a/receiver/main.py
+++ b/receiver/main.py
@@ -20,10 +20,16 @@ if __name__ == '__main__':
         print(f'[!] Session file {session_file} not found. Run init_session.py first.')
         raise SystemExit(1)
 
-    bot.start(
-        phone=settings.TG_PHONE_NUMBER,
-        code_callback=_ask_code,
-        password=_ask_password,
-    )
+    bot.connect()
+
+    if not bot.is_user_authorized():
+        bot.start(
+            phone=settings.TG_PHONE_NUMBER,
+            code_callback=_ask_code,
+            password=_ask_password,
+        )
+    else:
+        print(f'[+] Reusing existing session {session_file}')
+
     print('Bot is running!')
     bot.run_until_disconnected()


### PR DESCRIPTION
## Summary
- reconnect to the Telegram client if a session is found
- only prompt for a code when authorization is missing

## Testing
- `python -m py_compile receiver/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fd79741f4832ea60a11bd26f1d499