### PR TITLE
Fix handler registration and add startup log

### DIFF
--- a/receiver/handlers/__init__.py
+++ b/receiver/handlers/__init__.py
@@ -1,3 +1,20 @@
-from .conversations import familiarize_conv_handler
-from .webhook_forwarder import forward_all_messages
-from .logger import log_message
+
+def register_handlers() -> None:
+    """Import all handler modules to register their callbacks."""
+    from . import conversations as _conversations  # noqa: F401
+    from . import webhook_forwarder as _webhook_forwarder  # noqa: F401
+    from . import logger as _logger  # noqa: F401
+
+    # Export names for ``from handlers import *`` if desired
+    globals().update(
+        familiarize_conv_handler=_conversations.familiarize_conv_handler,
+        forward_all_messages=_webhook_forwarder.forward_all_messages,
+        log_message=_logger.log_message,
+    )
+
+__all__ = [
+    "register_handlers",
+    "familiarize_conv_handler",
+    "forward_all_messages",
+    "log_message",
+]

--- a/receiver/main.py
+++ b/receiver/main.py
@@ -3,7 +3,7 @@ import asyncio
 
 from config import bot, settings
 
-from handlers import *  # noqa: F401,F403 - register event handlers
+from handlers import register_handlers
 
 
 def _ask_code() -> str:
@@ -30,6 +30,10 @@ async def main() -> None:
         password=_ask_password,
     )
     print(f'[+] Using session {session_file}')
+
+    # Import handlers after the client has started to ensure they register
+    register_handlers()
+    print("Bot is fully running and listening for messages!")
 
     print('Bot is running!')
     await bot.run_until_disconnected()


### PR DESCRIPTION
## Summary
- ensure event handlers are imported after the client starts
- show a debug message when the bot is ready

## Testing
- `python -m py_compile receiver/main.py receiver/handlers/__init__.py receiver/handlers/logger.py receiver/handlers/conversations.py receiver/handlers/webhook_forwarder.py`
- `flake8` *(fails: command not found)*
- `pip install black==23.1.0` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_685fe85b5f98832e9157f8a29bd3ec88