### PR TITLE
Fix bot startup and logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
           - ./userbot_media:/media:ro
         tty: true
     receiver:
-        command: sh -c "python3 main.py & python3 media_server.py"
+        command: python3 run.py
         build:
             context: .
             dockerfile: receiver/Dockerfile

--- a/receiver/run.py
+++ b/receiver/run.py
@@ -1,0 +1,23 @@
+import asyncio
+from multiprocessing import Process
+
+from media_server import app
+from main import main as bot_main
+
+
+def run_media_server() -> None:
+    app.run(host="0.0.0.0", port=8181)
+
+
+async def run_both() -> None:
+    server = Process(target=run_media_server)
+    server.start()
+    try:
+        await bot_main()
+    finally:
+        server.terminate()
+        server.join()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_both())


### PR DESCRIPTION
## Summary
- add `run.py` to start both the bot and media server in one process
- call the new launcher from `docker-compose.yml`

## Testing
- `python3 -m py_compile receiver/run.py`

------
https://chatgpt.com/codex/tasks/task_e_685ffc2fd114832e949abd9f198d3cb7