### PR TITLE
Fix session storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
    `env_file` in `docker-compose.yml`).
 5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
 6.  You can pre-create a session by running `python init_session.py` once
-    outside of Docker.  The script reads credentials from `.env` and stores the
-    session file inside `sessions/`.  When executed locally the script
-    automatically rewrites the `/sessions/<name>` path from the environment to
-    the local `sessions/` directory so the file is visible to the containers.
+    outside of Docker.  The script reads credentials from `.env` and always
+    stores the session file inside `sessions/` in the repository so it will be
+    mounted into the containers.  Any absolute `/sessions/<name>` path from the
+    environment is rewritten automatically to this local directory.
 7.  Start the services with `docker-compose up`. If the session file is missing
     the receiver will prompt for the login code and create it automatically on
     the first run.

--- a/init_session.py
+++ b/init_session.py
@@ -29,10 +29,10 @@ def get_session_path(raw_path: str) -> Path:
     path = Path(raw_path)
 
     if path.is_absolute() and path.parts[:2] == ('/', 'sessions'):
-        # If running locally ``/sessions`` won't exist.  Save the file into the
-        # repository's sessions folder instead so Docker can mount it.
-        if not Path('/sessions').exists():
-            path = Path('sessions') / path.name
+        # Always store the session inside the repository so Docker can mount it.
+        # This avoids accidentally writing to an existing ``/sessions``
+        # directory on the host which would not be shared with the containers.
+        path = Path('sessions') / path.name
 
     return path
 


### PR DESCRIPTION
## Summary
- ensure `init_session.py` always stores session file in repository
- clarify README about session path

## Testing
- `python3 -m py_compile init_session.py`
- `python3 -m py_compile receiver/main.py`

------
https://chatgpt.com/codex/tasks/task_e_686010acd39c832eb552eb90a9c4c943