### PR TITLE
Fix env comment handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
 
 ### Configuration
 
-1.  Copy `.env.example` to `.env`, populate your Telegram API credentials, session name, phone number, webhook information and public domain settings (`PUBLIC_MEDIA_HOST`, `PUBLIC_MEDIA_PORT`). Keep the file in the repository root next to `docker-compose.yml`.
+1.  Copy `.env.example` to `.env` and populate your Telegram API credentials, session name, phone number, webhook information and public domain settings (`PUBLIC_MEDIA_HOST`, `PUBLIC_MEDIA_PORT`). Keep the file in the repository root next to `docker-compose.yml`. Inline comments after a `#` are ignored when running `init_session.py` so you may keep the examples as-is.
 2.  Create an empty `sessions/` directory next to the compose file. Docker Compose mounts this path into both services so they share one Telethon session.
    In your `.env` set `TG_SESSION_NAME=/sessions/tg_userbot` (or any name inside `/sessions`).
 3.  Ensure the `userbot_media` directory exists. Docker Compose mounts this path
@@ -73,10 +73,10 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
    `env_file` in `docker-compose.yml`).
 5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
 6.  You can pre-create a session by running `python init_session.py` once
-    outside of Docker.  The script reads credentials from `.env` and stores the
-    session file inside `sessions/`.  When executed locally the script
-    automatically rewrites the `/sessions/<name>` path from the environment to
-    the local `sessions/` directory so the file is visible to the containers.
+    outside of Docker.  The script reads credentials from `.env` and always
+    stores the session file inside `sessions/` in the repository so it will be
+    mounted into the containers.  Any absolute `/sessions/<name>` path from the
+    environment is rewritten automatically to this local directory.
 7.  Start the services with `docker-compose up`. If the session file is missing
     the receiver will prompt for the login code and create it automatically on
     the first run.


### PR DESCRIPTION
## Summary
- handle inline comments when parsing `.env` for session
- document that `.env` comments are ignored

## Testing
- `python3 -m py_compile init_session.py`
- `python3 -m py_compile receiver/main.py`


------
https://chatgpt.com/codex/tasks/task_e_686010acd39c832eb552eb90a9c4c943