### PR TITLE
Add deploy helper script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ And start up services:
 docker-compose up
 ```
 
+For convenience you may also run the helper script:
+```shell
+./deploy/deploy.sh
+```
+
 The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_MEDIA_PORT>/media`. Media links in webhook payloads are generated automatically using these variables.
 
 ### Configuration
@@ -72,7 +77,7 @@ The receiver will serve downloaded files on `http://<PUBLIC_MEDIA_HOST>:<PUBLIC_
 4.  Docker Compose loads the `.env` file automatically for both services (see
    `env_file` in `docker-compose.yml`).
 5.  Set `X_API_TOKEN` in `.env` and include this token in the `x-api-key` header when calling the sender API.
-6.  You can pre-create a session by running `python init_session.py` once
+6.  You can pre-create a session by running `python3 init_session.py` once
     outside of Docker.  The script reads credentials from `.env` and always
     stores the session file inside `sessions/` in the repository so it will be
     mounted into the containers.  Any absolute `/sessions/<name>` path from the

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,1 +1,33 @@
-# deploy script steps must be written here
+#!/usr/bin/env bash
+# Simple setup script for tg-bot-service
+
+set -e
+
+# Copy .env.example if .env does not exist
+if [ ! -f .env ]; then
+  echo "Copying .env.example to .env"
+  cp .env.example .env
+fi
+
+# Ensure required directories exist
+mkdir -p sessions userbot_media
+
+# Initialize Telegram session (requires python3)
+if command -v python3 >/dev/null 2>&1; then
+  python3 init_session.py
+else
+  echo "python3 not found. Please install Python 3 to generate the session."
+fi
+
+# Determine docker compose command
+if command -v docker-compose >/dev/null 2>&1; then
+  compose_cmd="docker-compose"
+else
+  compose_cmd="docker compose"
+fi
+
+# Build images and start services
+$compose_cmd build
+$compose_cmd up -d
+
+echo "tg-bot-service is up and running."


### PR DESCRIPTION
## Summary
- provide simple deployment helper script that builds images and starts services
- note `python3 init_session.py` and `deploy.sh` usage in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860511cf288832e9db1f0fc61005f0b